### PR TITLE
Fix extracting INFO fields when one is suffix of another

### DIFF
--- a/features/multisample.feature
+++ b/features/multisample.feature
@@ -79,3 +79,12 @@ Feature: Multi-sample VCF
     And I expect r.original.gts to be ["C","G"]
     And I expect r.original.gts[0] to be "C"
     And I expect r.original.gts[1] to be "G"
+    
+    # INFO fields with matching tails
+    Given multisample vcf line
+    """
+1 10723 . C G 73.85 . AC=4;AF=0.667;CIEND=999;END=111;AN=6;BaseQRankSum=1.300;DP=18;Dels=0.00;FS=3.680;HaplotypeScore=0.0000;MLEAC=4;MLEAF=0.667;MQ=20.49;MQ0=11;MQRankSum=1.754;QD=8.21;ReadPosRankSum=0.000 GT:AD:DP:GQ:PL  0|1 ./. 1/1:2,2:4:6:66,6,0  1/1:4,1:5:3:36,3,0  ./. ./.  0/0:6,0:6:3:0,3,33
+    """
+    When I parse the record
+    Then I expect r.info.end to be 111
+    And I expect r.info.ciend to be 999

--- a/features/step_definitions/multisample.rb
+++ b/features/step_definitions/multisample.rb
@@ -173,3 +173,10 @@ Then(/^I expect r\.original\.gts\[(\d+)\] to be "(.*?)"$/) do |arg1, arg2|
   expect(@rec1.original.gts[arg1.to_i]).to eq arg2
 end
 
+Then(/^I expect r\.info\.end to be (\d+)$/) do |arg1|
+  expect(@rec1.info.end).to eq arg1.to_i
+end
+
+Then(/^I expect r\.info\.ciend to be (\d+)$/) do |arg1|
+  expect(@rec1.info.ciend).to eq arg1.to_i
+end

--- a/lib/bio-vcf/vcfrecord.rb
+++ b/lib/bio-vcf/vcfrecord.rb
@@ -20,7 +20,7 @@ module BioVcf
       v = if @h
             @h[kupper]
           else
-            @info =~ /#{k}=([^;]+)/i
+            @info =~ /[\A;]#{k}=([^;]+)/i
             value = $1
             # p [m,value]
             # m = @info.match(/#{m.to_s.upcase}=(?<value>[^;]+)/) slower!


### PR DESCRIPTION
If one INFO field is suffix for another (e.g. END for CIEND) and CIEND
comes first, then r.info.end gives the value for CIEND, instead of END.

```ruby
s = "CIEND=999;END=111"
k = "END"
s =~ /#{k}=([^;]+)/i
value = $1 # values gives 999 instead of 111
s =~ /[\A;]#{k}=([^;]+)/i
value = $1 # values gives correct 111
```