### PR TITLE
Fix handling of VCF file with no records (only header)

### DIFF
--- a/bin/bio-vcf
+++ b/bin/bio-vcf
@@ -215,6 +215,7 @@ def parse_header line, samples, options
   print line if not options[:skip_header]
   STDIN.each_line do | headerline |
     if headerline !~ /^#/
+      # If no records in VCF, we never get here
       line = headerline
       break # end of header
     end
@@ -246,6 +247,10 @@ def parse_header line, samples, options
   end
   print header.printable_header_line(options[:set_header]),"\n" if options[:set_header]
   VcfRdf::header if options[:rdf]
+  if line =~ /^#/
+    # We did not read a record
+    line = nil
+  end
   return header,line
 end
 
@@ -415,7 +420,11 @@ begin
     # ---- Parse the header lines (chomps from STDIN)
     #      and returns header info and the current line
     if line =~ /^#/
-      header,line = parse_header(line,samples,options)
+      header, line = parse_header(line,samples,options)
+      if line.nil?
+        # No line after header, to there are no records to process
+        break
+      end
     end
     # p [line_number,line]
     # ---- After the header continue processing

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -68,4 +68,7 @@ Feature: Command-line interface (CLI)
     When I execute "./bin/bio-vcf -q --timeout 4 --num-threads 4 --thread-lines 4 --filter 't.info.dp>2'"
     Then I expect an error and the named output to match the named output "thread4_4_failed_filter" in under 30 seconds
 
-
+  Scenario: Test VCF with no records
+    Given I have input file(s) named "test/data/input/empty.vcf"
+    When I execute "./bin/bio-vcf --timeout=5"
+    Then I expect no errors

--- a/features/step_definitions/cli-feature.rb
+++ b/features/step_definitions/cli-feature.rb
@@ -19,3 +19,7 @@ end
 Then(/^I expect an error and the named output to match the named output "(.*?)" in under (\d+) seconds$/) do |arg1,arg2|
   RegressionTest::CliExec::exec(@cmd,arg1,ignore: '(FATAL|Waiting|from|vcf|Options|Final pid)',should_fail: true,timeout:arg2.to_i).should be_truthy
 end
+
+Then(/^I expect no errors$/) do 
+  RegressionTest::CliExec::exec(@cmd, "empty").should be_truthy
+end

--- a/test/data/input/empty.vcf
+++ b/test/data/input/empty.vcf
@@ -1,0 +1,2 @@
+##fileformat=VCFv4.0
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO

--- a/test/data/regression/empty.ref
+++ b/test/data/regression/empty.ref
@@ -1,0 +1,2 @@
+##fileformat=VCFv4.0
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO


### PR DESCRIPTION
If input VCF contains no records (only header), then running `bio-vcf` results in error message:
    Unexpected line ##fileformat=VCFv4.0

This pull request fixes this behaviour: only header is printed with no errors.